### PR TITLE
Added Money to Chat function (sourcecode from WarMod BFG)

### DIFF
--- a/scripting/include/pugsetup.inc
+++ b/scripting/include/pugsetup.inc
@@ -25,6 +25,9 @@ enum Permissions {
     Permission_Leader = 1
 };
 
+// Offsets
+new g_iAccount = -1;
+
 /**
  * Called when the game types are read and added each map.
  * @noreturn
@@ -248,4 +251,39 @@ stock MapType MapTypeFromString(const char[] mapTypeString,
         LogError("Invalid map type: \"%s\", allowed values: \"current\", \"vote\", \"veto\"", mapTypeString);
 
     return fallback;
+}
+
+/**
+*  get the comma'd string version of an integer
+*
+* @param  OldMoney			the integer to convert
+* @param  String:NewMoney	the buffer to save the string in
+* @param  size				the size of the buffer
+* @noreturn
+*/
+
+stock IntToMoney(OldMoney, String:NewMoney[], size)
+{
+    new String:Temp[32];
+    new String:OldMoneyStr[32];
+    new tempChar;
+    new RealLen = 0;
+
+    IntToString(OldMoney, OldMoneyStr, sizeof(OldMoneyStr));
+
+    for (new i = strlen(OldMoneyStr) - 1; i >= 0; i--)
+    {
+        if (RealLen % 3 == 0 && RealLen != strlen(OldMoneyStr) && i != strlen(OldMoneyStr)-1)
+        {
+            tempChar = OldMoneyStr[i];
+            Format(Temp, sizeof(Temp), "%s,%s", tempChar, Temp);
+        }
+        else
+        {
+            tempChar = OldMoneyStr[i];
+            Format(Temp, sizeof(Temp), "%s%s", tempChar, Temp);
+        }
+        RealLen++;
+    }
+    Format(NewMoney, size, "%s", Temp);
 }

--- a/scripting/pugsetup_chatmoney.sp
+++ b/scripting/pugsetup_chatmoney.sp
@@ -1,0 +1,95 @@
+#pragma semicolon 1
+#include <cstrike>
+#include <sourcemod>
+
+#include "include/pugsetup.inc"
+#include "pugsetup/generic.sp"
+
+#define MAX_HOST_LENGTH 256
+
+Handle g_hEnabled = INVALID_HANDLE;
+
+public Plugin:myinfo = {
+    name = "CS:GO PugSetup: write team money to chat",
+    author = "Versatile_BFG/jkroepke",
+    description = "Write the teamsmebers money to the chat (like WarMod)",
+    version = PLUGIN_VERSION,
+    url = "https://github.com/splewis/csgo-pug-setup"
+};
+
+public void OnPluginStart() {
+    LoadTranslations("pugsetup.phrases");
+    g_hEnabled = CreateConVar("sm_pugsetup_chatmoney_enabled", "1", "Whether the plugin is enabled");
+	g_iAccount = FindSendPropOffs("CCSPlayer", "m_iAccount");
+
+    AutoExecConfig(true, "pugsetup_chatmoney", "sourcemod/pugsetup");
+
+    HookEvent("round_start", Event_Round_Start);
+}
+
+public Event_Round_Start(Handle event, const char[] name, bool dontBroadcast) {
+    if (!IsMatchLive() || GetConVarInt(g_hEnabled) == 0)
+        return;
+
+    new the_money[MAXPLAYERS + 1];
+    new num_players;
+
+    // sort by money
+    for (new i = 1; i <= MaxClients; i++)
+    {
+        if (IsClientInGame(i) && !IsFakeClient(i) && GetClientTeam(i) > 1)
+        {
+            the_money[num_players] = i;
+            num_players++;
+        }
+    }
+
+    SortCustom1D(the_money, num_players, SortMoney);
+
+    new String:player_name[64];
+    new String:player_money[10];
+    new String:has_weapon[1];
+    new pri_weapon;
+
+    // display team players money
+    for (new i = 1; i <= MaxClients; i++)
+    {
+        for (new x = 0; x < num_players; x++)
+        {
+            GetClientName(the_money[x], player_name, sizeof(player_name));
+            if (IsClientInGame(i) && !IsFakeClient(i) && GetClientTeam(i) == GetClientTeam(the_money[x]))
+            {
+                pri_weapon = GetPlayerWeaponSlot(the_money[x], 0);
+                if (pri_weapon == -1)
+                {
+                    has_weapon = ">";
+                }
+                else
+                {
+                    has_weapon = "\0";
+                }
+                IntToMoney(GetEntData(the_money[x], g_iAccount), player_money, sizeof(player_money));
+                PrintToChat(i, "\x01$%s \x04%s> \x03%s", player_money, has_weapon, player_name);
+            }
+        }
+    }
+}
+
+public SortMoney(elem1, elem2, const array[], Handle:hndl)
+{
+	new money1 = GetEntData(elem1, g_iAccount);
+	new money2 = GetEntData(elem2, g_iAccount);
+	
+	if (money1 > money2)
+	{
+		return -1;
+	}
+	else if (money1 == money2)
+	{
+		return 0;
+	}
+	else
+	{
+		return 1;
+	}
+}


### PR DESCRIPTION
Hi,

this pull request add a plugin that add an function to write the teammembers money to the chat on round begin.

I use the code from WarMod_BFG and adapt it for pugsetup.

Tested with 1.7.0-dev+5106

Currently compiler iusses:

```
pugsetup_chatmoney.sp(24) : warning 217: loose indentation
pugsetup_chatmoney.sp(26) : warning 217: loose indentation
```

I have no ideas about the langauge soucepawn and the souremod api. Sorry for every quallity iusses.
