### PR TITLE
practicemode: invalid return param

### DIFF
--- a/scripting/pugsetup_practicemode.sp
+++ b/scripting/pugsetup_practicemode.sp
@@ -547,7 +547,7 @@ public Action Timer_GivePlayersMoney(Handle timer) {
     return Plugin_Continue;
 }
 
-public int OnEntityCreated(int entity, const char[] className) {
+public void OnEntityCreated(int entity, const char[] className) {
     if (!g_GrenadeTrajectory || !IsValidEntity(entity) || !IsGrenadeProjectile(className))
         return;
 


### PR DESCRIPTION
I am not sure with what versionb this is supposed to compile (e.g. your other projects depends on smlib, whcih seems to be for version 1.6?, at least I couldnt get to compile it without manually patching a few errors).

On 1.7 though this change is required:

```
ERROR: Failed to compile pugsetup_practicemode, from ./smbuild
././scripting/pugsetup_practicemode.sp(550) : error 180: function return type differs from prototype. expected 'void', but got 'int'
```