### PR TITLE
Display max team size numbers in setup menu

### DIFF
--- a/scripting/pugsetup/setupmenus.sp
+++ b/scripting/pugsetup/setupmenus.sp
@@ -232,7 +232,7 @@ public void TeamSizeMenu(int client) {
 
   for (int i = 1; i <= g_MaxTeamSizeCvar.IntValue; i++) {
     char teamSizeStr[32];
-    IntToString(i, teamSizeStr, sizeof(teamSizeStr))
+    IntToString(i, teamSizeStr, sizeof(teamSizeStr));
 
     AddMenuInt(menu, i, teamSizeStr);
   }

--- a/scripting/pugsetup/setupmenus.sp
+++ b/scripting/pugsetup/setupmenus.sp
@@ -230,8 +230,12 @@ public void TeamSizeMenu(int client) {
   menu.ExitButton = false;
   menu.ExitBackButton = true;
 
-  for (int i = 1; i <= g_MaxTeamSizeCvar.IntValue; i++)
-    AddMenuInt(menu, i, "");
+  for (int i = 1; i <= g_MaxTeamSizeCvar.IntValue; i++) {
+    char teamSizeStr[32];
+    IntToString(i, teamSizeStr, sizeof(teamSizeStr))
+
+    AddMenuInt(menu, i, teamSizeStr);
+  }
 
   DisplayMenu(menu, client, MENU_TIME_FOREVER);
 }


### PR DESCRIPTION
The value of the max team size selection should be displayed in the menus.

When `sm_pugsetup_max_team_size` is large enough that paging occurs, it's confusing that on the second page selection `4.` corresponds to team size 10.