### PR TITLE
Add minutes and seconds to demo filename, time should come first

### DIFF
--- a/scripting/pugsetup.sp
+++ b/scripting/pugsetup.sp
@@ -242,10 +242,10 @@ public void OnPluginStart() {
       "sm_pugsetup_autoupdate", "1",
       "Whether the plugin may (if the \"Updater\" plugin is loaded) automatically update.");
   g_DemoNameFormatCvar = CreateConVar(
-      "sm_pugsetup_demo_name_format", "pug_{MAP}_{TIME}",
+      "sm_pugsetup_demo_name_format", "pug_{TIME}_{MAP}",
       "Naming scheme for demos. You may use {MAP}, {TIME}, and {TEAMSIZE}. Make sure there are no spaces or colons in this.");
   g_DemoTimeFormatCvar = CreateConVar(
-      "sm_pugsetup_time_format", "%Y-%m-%d_%H",
+      "sm_pugsetup_time_format", "%Y-%m-%d_%H%M%S",
       "Time format to use when creating demo file names. Don't tweak this unless you know what you're doing! Avoid using spaces or colons.");
   g_DisplayMapVotesCvar =
       CreateConVar("sm_pugsetup_display_map_votes", "1",


### PR DESCRIPTION
To maintain file order, time should come first for better file ordering.