### PR TITLE
Add "mp_give_player_c4 1" to live.cfg

### DIFF
--- a/cfg/sourcemod/pugsetup/live.cfg
+++ b/cfg/sourcemod/pugsetup/live.cfg
@@ -10,6 +10,7 @@ mp_c4timer 40
 mp_death_drop_gun 1
 mp_endmatch_votenextmap 0
 mp_freezetime 15
+mp_give_player_c4 1
 mp_halftime_pausetimer 0
 mp_ignore_round_win_conditions 0
 mp_limitteams 0


### PR DESCRIPTION
According to the readme, and the author: it's still good practice to have that cvar in the live config. #240