### PR TITLE
Add specific hint status messages

### DIFF
--- a/scripting/pugsetup.sp
+++ b/scripting/pugsetup.sp
@@ -604,7 +604,7 @@ public Action Timer_CheckReady(Handle timer) {
       if (g_TeamType == TeamType_Captains) {
         if (IsPlayer(g_capt1) && IsPlayer(g_capt2) && g_capt1 != g_capt2) {
           g_LiveTimerRunning = false;
-          PrintHintTextToAll("%t", "ReadyStatusAllReadyPick", readyPlayers, totalPlayers);
+          PrintHintTextToAll("%t\n%t", "ReadyStatusPlayers", readyPlayers, totalPlayers, "ReadyStatusAllReadyPick");
           CreateTimer(1.0, StartPicking, _, TIMER_FLAG_NO_MAPCHANGE);
           return Plugin_Stop;
         } else {
@@ -614,9 +614,9 @@ public Action Timer_CheckReady(Handle timer) {
         g_LiveTimerRunning = false;
 
         if (g_AutoLive) {
-          PrintHintTextToAll("%t", "ReadyStatusAllReady", readyPlayers, totalPlayers);
+          PrintHintTextToAll("%t\n%t", "ReadyStatusPlayers", readyPlayers, totalPlayers, "ReadyStatusAllReady");
         } else {
-          PrintHintTextToAll("%t", "ReadyStatusAllReadyWaiting", readyPlayers, totalPlayers);
+          PrintHintTextToAll("%t\n%t", "ReadyStatusPlayers", readyPlayers, totalPlayers, "ReadyStatusAllReadyWaiting");
         }
 
         ReadyToStart();
@@ -627,7 +627,7 @@ public Action Timer_CheckReady(Handle timer) {
       if (g_MapType == MapType_Veto) {
         if (IsPlayer(g_capt1) && IsPlayer(g_capt2) && g_capt1 != g_capt2) {
           g_LiveTimerRunning = false;
-          PrintHintTextToAll("%t", "ReadyStatusAllReadyVeto", readyPlayers, totalPlayers);
+          PrintHintTextToAll("%t\n%t", "ReadyStatusPlayers", readyPlayers, totalPlayers, "ReadyStatusAllReadyVeto");
           PugSetup_MessageToAll("%t", "VetoMessage");
           CreateTimer(2.0, MapSetup, _, TIMER_FLAG_NO_MAPCHANGE);
           return Plugin_Stop;
@@ -637,7 +637,7 @@ public Action Timer_CheckReady(Handle timer) {
 
       } else {
         g_LiveTimerRunning = false;
-        PrintHintTextToAll("%t", "ReadyStatusAllReadyVote", readyPlayers, totalPlayers);
+        PrintHintTextToAll("%t\n%t", "ReadyStatusPlayers", readyPlayers, totalPlayers, "ReadyStatusAllReadyVote");
         PugSetup_MessageToAll("%t", "VoteMessage");
         CreateTimer(2.0, MapSetup, _, TIMER_FLAG_NO_MAPCHANGE);
         return Plugin_Stop;

--- a/scripting/pugsetup.sp
+++ b/scripting/pugsetup.sp
@@ -604,6 +604,7 @@ public Action Timer_CheckReady(Handle timer) {
       if (g_TeamType == TeamType_Captains) {
         if (IsPlayer(g_capt1) && IsPlayer(g_capt2) && g_capt1 != g_capt2) {
           g_LiveTimerRunning = false;
+          PrintHintTextToAll("%t", "ReadyStatusAllReadyPick", readyPlayers, totalPlayers);
           CreateTimer(1.0, StartPicking, _, TIMER_FLAG_NO_MAPCHANGE);
           return Plugin_Stop;
         } else {
@@ -611,6 +612,13 @@ public Action Timer_CheckReady(Handle timer) {
         }
       } else {
         g_LiveTimerRunning = false;
+
+        if (g_AutoLive) {
+          PrintHintTextToAll("%t", "ReadyStatusAllReady", readyPlayers, totalPlayers);
+        } else {
+          PrintHintTextToAll("%t", "ReadyStatusAllReadyWaiting", readyPlayers, totalPlayers);
+        }
+
         ReadyToStart();
         return Plugin_Stop;
       }
@@ -619,6 +627,7 @@ public Action Timer_CheckReady(Handle timer) {
       if (g_MapType == MapType_Veto) {
         if (IsPlayer(g_capt1) && IsPlayer(g_capt2) && g_capt1 != g_capt2) {
           g_LiveTimerRunning = false;
+          PrintHintTextToAll("%t", "ReadyStatusAllReadyVeto", readyPlayers, totalPlayers);
           PugSetup_MessageToAll("%t", "VetoMessage");
           CreateTimer(2.0, MapSetup, _, TIMER_FLAG_NO_MAPCHANGE);
           return Plugin_Stop;
@@ -628,6 +637,7 @@ public Action Timer_CheckReady(Handle timer) {
 
       } else {
         g_LiveTimerRunning = false;
+        PrintHintTextToAll("%t", "ReadyStatusAllReadyVote", readyPlayers, totalPlayers);
         PugSetup_MessageToAll("%t", "VoteMessage");
         CreateTimer(2.0, MapSetup, _, TIMER_FLAG_NO_MAPCHANGE);
         return Plugin_Stop;

--- a/translations/pugsetup.phrases.txt
+++ b/translations/pugsetup.phrases.txt
@@ -36,19 +36,24 @@
 	{
 		"en"		"The game is already live!"
 	}
-	"ReadyStatus"
-	{
-		"#format"	"{1:i},{2:i},{3:s}"
-		"en"		"{1} out of {2} players are ready\nType {3} to ready up"
-	}
 	"ReadyStatusPlayers"
 	{
 		"#format"	"{1:i},{2:i}"
 		"en"		"{1} out of {2} players are ready"
 	}
+	"ReadyStatus"
+	{
+		"#format"	"{1:i},{2:i},{3:s}"
+		"en"		"{1} out of {2} players are ready\nType {3} to ready up"
+	}
+	"ReadyStatusCaptains"
+	{
+		"#format"	"{1:i},{2:i},{3:s},{4:s}"
+		"en"		"{1} out of {2} players are ready\nCaptain 1: {3}\nCaptain 2: {4}"
+	}
 	"ReadyStatusAllReadyPick"
 	{
-		"en"		"Starting pick players..."
+		"en"		"Starting player picking..."
 	}
 	"ReadyStatusAllReady"
 	{
@@ -60,16 +65,11 @@
 	}
 	"ReadyStatusAllReadyVeto"
 	{
-		"en"		"Starting veto process..."
+		"en"		"Starting map veto process..."
 	}
 	"ReadyStatusAllReadyVote"
 	{
 		"en"		"Starting map voting..."
-	}
-	"ReadyStatusCaptains"
-	{
-		"#format"	"{1:i},{2:i},{3:s},{4:s}"
-		"en"		"{1} out of {2} players are ready\nCaptain 1: {3}\nCaptain 2: {4}"
 	}
 	"CaptainNotSelected"
 	{

--- a/translations/pugsetup.phrases.txt
+++ b/translations/pugsetup.phrases.txt
@@ -41,30 +41,30 @@
 		"#format"	"{1:i},{2:i},{3:s}"
 		"en"		"{1} out of {2} players are ready\nType {3} to ready up"
 	}
-	"ReadyStatusAllReadyPick"
+	"ReadyStatusPlayers"
 	{
 		"#format"	"{1:i},{2:i}"
-		"en"		"{1} out of {2} players are ready\nStarting pick players..."
+		"en"		"{1} out of {2} players are ready"
+	}
+	"ReadyStatusAllReadyPick"
+	{
+		"en"		"Starting pick players..."
 	}
 	"ReadyStatusAllReady"
 	{
-		"#format"	"{1:i},{2:i}"
-		"en"		"{1} out of {2} players are ready\nStarting match..."
+		"en"		"Starting match..."
 	}
 	"ReadyStatusAllReadyWaiting"
 	{
-		"#format"	"{1:i},{2:i}"
-		"en"		"{1} out of {2} players are ready\nWaiting to start..."
+		"en"		"Waiting to start..."
 	}
 	"ReadyStatusAllReadyVeto"
 	{
-		"#format"	"{1:i},{2:i}"
-		"en"		"{1} out of {2} players are ready\nStarting veto process..."
+		"en"		"Starting veto process..."
 	}
 	"ReadyStatusAllReadyVote"
 	{
-		"#format"	"{1:i},{2:i}"
-		"en"		"{1} out of {2} players are ready\nStarting map voting..."
+		"en"		"Starting map voting..."
 	}
 	"ReadyStatusCaptains"
 	{

--- a/translations/pugsetup.phrases.txt
+++ b/translations/pugsetup.phrases.txt
@@ -41,6 +41,31 @@
 		"#format"	"{1:i},{2:i},{3:s}"
 		"en"		"{1} out of {2} players are ready\nType {3} to ready up"
 	}
+	"ReadyStatusAllReadyPick"
+	{
+		"#format"	"{1:i},{2:i}"
+		"en"		"{1} out of {2} players are ready\nStarting pick players..."
+	}
+	"ReadyStatusAllReady"
+	{
+		"#format"	"{1:i},{2:i}"
+		"en"		"{1} out of {2} players are ready\nStarting match..."
+	}
+	"ReadyStatusAllReadyWaiting"
+	{
+		"#format"	"{1:i},{2:i}"
+		"en"		"{1} out of {2} players are ready\nWaiting to start..."
+	}
+	"ReadyStatusAllReadyVeto"
+	{
+		"#format"	"{1:i},{2:i}"
+		"en"		"{1} out of {2} players are ready\nStarting veto process..."
+	}
+	"ReadyStatusAllReadyVote"
+	{
+		"#format"	"{1:i},{2:i}"
+		"en"		"{1} out of {2} players are ready\nStarting map voting..."
+	}
 	"ReadyStatusCaptains"
 	{
 		"#format"	"{1:i},{2:i},{3:s},{4:s}"


### PR DESCRIPTION
For: starting pick players, starting match, waiting to start, starting veto process, starting map voting.
No more 9/10 ready hint message when everyone is ready. Fixing issue #256

I was able to compile and test these scenarios: ReadyStatusAllReady, ReadyStatusAllReadyWaiting, ReadyStatusAllReadyVote