### PR TITLE
Disable mp_limitteams during warmup as well

### DIFF
--- a/cfg/sourcemod/pugsetup/warmup.cfg
+++ b/cfg/sourcemod/pugsetup/warmup.cfg
@@ -7,6 +7,7 @@ mp_death_drop_gun 0
 mp_free_armor 2
 mp_freezetime 1
 mp_friendlyfire 0
+mp_limitteams 0
 mp_maxrounds 30
 mp_respawn_immunitytime 2
 mp_respawn_on_death_ct 1


### PR DESCRIPTION
You won't see "Too many Terrorits/Counter-terrorist" message when trying to join a team which has way more players than the other.
Disabling this var would allow you to join a team, regardless how many players are in that team. It is handy with manual teamtype (already decided teams).
It is disabled in the live.cfg as well.
mp_limitteams: Max # of players 1 team can have over another (0 disables check) Default: 2