### PR TITLE
Create undocumented on_setup.cfg

### DIFF
--- a/cfg/sourcemod/pugsetup/on_setup.cfg
+++ b/cfg/sourcemod/pugsetup/on_setup.cfg
@@ -1,0 +1,1 @@
+// Optional cfg, executed when the setup phase is over and the ready-up period should begin.


### PR DESCRIPTION
This optional cfg is executed when the setup phase is over and the ready-up period should begin.