### PR TITLE
Speed up the LO3

### DIFF
--- a/scripting/pugsetup.sp
+++ b/scripting/pugsetup.sp
@@ -1850,7 +1850,7 @@ public void StartGame() {
     ScrambleTeams();
   }
 
-  CreateTimer(3.0, Timer_BeginMatch);
+  CreateTimer(2.0, Timer_BeginMatch);
   ExecGameConfigs();
   if (InWarmup()) {
     EndWarmup();

--- a/scripting/pugsetup.sp
+++ b/scripting/pugsetup.sp
@@ -1860,10 +1860,10 @@ public void StartGame() {
 public Action Timer_BeginMatch(Handle timer) {
   if (g_DoKnifeRound) {
     ChangeState(GameState_KnifeRound);
-    CreateTimer(3.0, StartKnifeRound, _, TIMER_FLAG_NO_MAPCHANGE);
+    CreateTimer(1.0, StartKnifeRound, _, TIMER_FLAG_NO_MAPCHANGE);
   } else {
     ChangeState(GameState_GoingLive);
-    CreateTimer(3.0, BeginLO3, _, TIMER_FLAG_NO_MAPCHANGE);
+    CreateTimer(1.0, BeginLO3, _, TIMER_FLAG_NO_MAPCHANGE);
   }
 }
 

--- a/scripting/pugsetup.sp
+++ b/scripting/pugsetup.sp
@@ -1850,7 +1850,7 @@ public void StartGame() {
     ScrambleTeams();
   }
 
-  CreateTimer(2.0, Timer_BeginMatch);
+  CreateTimer(3.0, Timer_BeginMatch);
   ExecGameConfigs();
   if (InWarmup()) {
     EndWarmup();
@@ -1860,10 +1860,10 @@ public void StartGame() {
 public Action Timer_BeginMatch(Handle timer) {
   if (g_DoKnifeRound) {
     ChangeState(GameState_KnifeRound);
-    CreateTimer(1.0, StartKnifeRound, _, TIMER_FLAG_NO_MAPCHANGE);
+    CreateTimer(3.0, StartKnifeRound, _, TIMER_FLAG_NO_MAPCHANGE);
   } else {
     ChangeState(GameState_GoingLive);
-    CreateTimer(1.0, BeginLO3, _, TIMER_FLAG_NO_MAPCHANGE);
+    CreateTimer(3.0, BeginLO3, _, TIMER_FLAG_NO_MAPCHANGE);
   }
 }
 

--- a/scripting/pugsetup/liveon3.sp
+++ b/scripting/pugsetup/liveon3.sp
@@ -28,8 +28,8 @@ public Action BeginLO3(Handle timer) {
     CreateTimer(2.0, Restart2);
   } else {
     // single restart
-    RestartGame(5);
-    CreateTimer(5.1, MatchLive);
+    RestartGame(3);
+    CreateTimer(3.1, MatchLive);
   }
 
   return Plugin_Handled;
@@ -51,8 +51,8 @@ public Action Restart3(Handle timer) {
     return Plugin_Handled;
 
   PugSetup_MessageToAll("%t", "RestartCounter", 3);
-  RestartGame(5);
-  CreateTimer(5.1, MatchLive);
+  RestartGame(3);
+  CreateTimer(3.1, MatchLive);
 
   return Plugin_Handled;
 }

--- a/scripting/pugsetup/liveon3.sp
+++ b/scripting/pugsetup/liveon3.sp
@@ -25,7 +25,7 @@ public Action BeginLO3(Handle timer) {
     // start lo3
     PugSetup_MessageToAll("%t", "RestartCounter", 1);
     RestartGame(1);
-    CreateTimer(3.0, Restart2);
+    CreateTimer(2.0, Restart2);
   } else {
     // single restart
     RestartGame(5);
@@ -41,7 +41,7 @@ public Action Restart2(Handle timer) {
 
   PugSetup_MessageToAll("%t", "RestartCounter", 2);
   RestartGame(1);
-  CreateTimer(4.0, Restart3);
+  CreateTimer(2.0, Restart3);
 
   return Plugin_Handled;
 }


### PR DESCRIPTION
Problems which may be fixed with this PR;
Have to wait too much time before some event starts:
- We have to wait 5 seconds to even start the KnifeRound/GoingLive state - **not changed (reverted) in this PR**
- The LO3 Timers are too much waiting: 1st restart wait: 7sec (including starting of the state), 2nd restart wait: 3 sec, 3rd restart wait: 8sec

This PR saves 5 seconds on Live On Three restarts and makes it more consistent.