### PR TITLE
Add example to warmup.cfg how to disable plugins

### DIFF
--- a/cfg/sourcemod/pugsetup/warmup.cfg
+++ b/cfg/sourcemod/pugsetup/warmup.cfg
@@ -24,3 +24,7 @@ sv_alltalk 1
 sv_auto_full_alltalk_during_warmup_half_end 1
 sv_competitive_official_5v5 1
 sv_full_alltalk 1
+
+// Disable plugins
+// sm_retakes_enabled 0
+// sm_multi1v1_enabled 0


### PR DESCRIPTION
Based on the [Wiki page](https://github.com/splewis/csgo-pug-setup/wiki/Frequently-Asked-Questions#how-can-i-enabledisable-other-plugins-when-a-pug-startsends).