### PR TITLE
Add mp_maxmoney 16000 into warmup.cfg to force it

### DIFF
--- a/cfg/sourcemod/pugsetup/warmup.cfg
+++ b/cfg/sourcemod/pugsetup/warmup.cfg
@@ -8,6 +8,7 @@ mp_free_armor 2
 mp_freezetime 1
 mp_friendlyfire 0
 mp_limitteams 0
+mp_maxmoney 16000
 mp_maxrounds 30
 mp_respawn_immunitytime 2
 mp_respawn_on_death_ct 1


### PR DESCRIPTION
Otherwise if you run casual mode for example, the default maxmoney there is 10000, so you would have only 10000 in the warmup as well.
In Wingman the default maxmoney is 8000.
With this PR, you will always have 16000.

I'am open for discussion, maybe not needed.