### PR TITLE
Fixed Coach switching after Knife

### DIFF
--- a/scripting/pugsetup/kniferounds.sp
+++ b/scripting/pugsetup/kniferounds.sp
@@ -89,6 +89,7 @@ public void EndKnifeRound(bool swap) {
           SwitchPlayerTeam(i, CS_TEAM_T);
 
         } else if (IsClientCoaching(i)) {
+          team = GetCoachTeam(i);
           if (team == CS_TEAM_T) {
             UpdateCoachTarget(i, CS_TEAM_CT);
           } else if (team == CS_TEAM_CT) {

--- a/scripting/pugsetup/util.sp
+++ b/scripting/pugsetup/util.sp
@@ -462,6 +462,10 @@ stock bool IsClientCoaching(int client) {
          GetEntProp(client, Prop_Send, "m_iCoachingTeam") != 0;
 }
 
+stock int GetCoachTeam(int client) {
+  return GetEntProp(client, Prop_Send, "m_iCoachingTeam");
+}
+
 stock void UpdateCoachTarget(int client, int csTeam) {
   SetEntProp(client, Prop_Send, "m_iCoachingTeam", csTeam);
 }


### PR DESCRIPTION
`GetClientTeam` always returns `CS_TEAM_SPECTATOR` for Coaches. 
`GetEntProp(client, Prop_Send, "m_iCoachingTeam")` returns the correct Team (`CS_TEAM_CT` or `CS_TEAM_T`)
This commit fixes issue #212 