### PR TITLE
Add ABBABAAB snaking for captain picks

### DIFF
--- a/scripting/pugsetup.sp
+++ b/scripting/pugsetup.sp
@@ -305,7 +305,7 @@ public void OnPluginStart() {
                                     "Whether the sm_setup and sm_10man commands are enabled");
   g_SnakeCaptainsCvar = CreateConVar(
       "sm_pugsetup_snake_captain_picks", "0",
-      "If set to 0: captains pick players in a ABABABAB order. If set to 1, in a ABBAABBA order. If set to 2, in a ABBABABA order.");
+      "If set to 0: captains pick players in a ABABABAB order. If set to 1, in a ABBAABBA order. If set to 2, in a ABBABABA order. If set to 3, in a ABBABAAB order.");
   g_StartDelayCvar =
       CreateConVar("sm_pugsetup_start_delay", "5",
                    "How many seconds of a countdown phase right before the lo3 process begins.", _,

--- a/scripting/pugsetup/captainpickmenus.sp
+++ b/scripting/pugsetup/captainpickmenus.sp
@@ -195,6 +195,7 @@ static int GetNextCaptain(int captain) {
       g_PickCounter--;
       return captain;
     }
+  }
   if (GetConVarInt(g_SnakeCaptainsCvar) == 2) {
     if (g_PickCounter == 0) {
       g_PickCounter++;

--- a/scripting/pugsetup/captainpickmenus.sp
+++ b/scripting/pugsetup/captainpickmenus.sp
@@ -195,7 +195,7 @@ static int GetNextCaptain(int captain) {
       g_PickCounter--;
       return captain;
     }
-  } else {
+  if (GetConVarInt(g_SnakeCaptainsCvar) == 2) {
     if (g_PickCounter == 0) {
       g_PickCounter++;
       return OtherCaptain(captain);
@@ -204,6 +204,22 @@ static int GetNextCaptain(int captain) {
       g_PickCounter++;
       return captain;
     } else {
+      return OtherCaptain(captain);
+    }
+  } else {
+    if (g_PickCounter == 0) {
+      g_PickCounter++;
+      return OtherCaptain(captain);
+    }
+    if (g_PickCounter == 1) {
+      g_PickCounter++;
+      return captain;
+    }
+    if (g_PickCounter == 5) {
+      g_PickCounter++;
+      return captain;
+    } else {
+      g_PickCounter++;
       return OtherCaptain(captain);
     }
   }


### PR DESCRIPTION
This is the usual picking order my group uses for 5v5 pug setups so we'd love for this to be officially added to the plugin.