### PR TITLE
Fixed bug in instant runoff voting

### DIFF
--- a/scripting/pugsetup/instantrunoffvote.sp
+++ b/scripting/pugsetup/instantrunoffvote.sp
@@ -102,7 +102,7 @@ public int MapSelectionHandler(Menu menu, MenuAction action, int param1, int par
       ShowInstantRunoffMapVote(client, g_ClientMapPosition[client]);
     } else {
       for (int i = 1; i <= MaxClients; i++) {
-        if (IsPlayer(i) && g_ClientMapPosition[client] < kIRVNumMapsToPick) {
+        if (IsPlayer(i) && g_ClientMapPosition[i] < kIRVNumMapsToPick) {
           return 0;
         }
       }


### PR DESCRIPTION
There was a bug in the instant runoff voting, caused by a typo.
The index in the for-loop was not used for the map position check, causing to instantly end the vote if anyone finished their third vote.