### PR TITLE
Display "<numReady> of <neededPlayers>".

### DIFF
--- a/scripting/pugsetup.sp
+++ b/scripting/pugsetup.sp
@@ -595,7 +595,9 @@ public Action Timer_CheckReady(Handle timer) {
     }
   }
 
-  if (totalPlayers >= PugSetup_GetPugMaxPlayers()) {
+  int neededPlayers = PugSetup_GetPugMaxPlayers();
+
+  if (totalPlayers >= neededPlayers) {
     GiveReadyHints();
   }
 
@@ -608,7 +610,7 @@ public Action Timer_CheckReady(Handle timer) {
       if (g_TeamType == TeamType_Captains) {
         if (IsPlayer(g_capt1) && IsPlayer(g_capt2) && g_capt1 != g_capt2) {
           g_LiveTimerRunning = false;
-          PrintHintTextToAll("%t\n%t", "ReadyStatusPlayers", readyPlayers, totalPlayers,
+          PrintHintTextToAll("%t\n%t", "ReadyStatusPlayers", readyPlayers, neededPlayers,
                              "ReadyStatusAllReadyPick");
           CreateTimer(1.0, StartPicking, _, TIMER_FLAG_NO_MAPCHANGE);
           return Plugin_Stop;
@@ -619,10 +621,10 @@ public Action Timer_CheckReady(Handle timer) {
         g_LiveTimerRunning = false;
 
         if (g_AutoLive) {
-          PrintHintTextToAll("%t\n%t", "ReadyStatusPlayers", readyPlayers, totalPlayers,
+          PrintHintTextToAll("%t\n%t", "ReadyStatusPlayers", readyPlayers, neededPlayers,
                              "ReadyStatusAllReady");
         } else {
-          PrintHintTextToAll("%t\n%t", "ReadyStatusPlayers", readyPlayers, totalPlayers,
+          PrintHintTextToAll("%t\n%t", "ReadyStatusPlayers", readyPlayers, neededPlayers,
                              "ReadyStatusAllReadyWaiting");
         }
 
@@ -634,7 +636,7 @@ public Action Timer_CheckReady(Handle timer) {
       if (g_MapType == MapType_Veto) {
         if (IsPlayer(g_capt1) && IsPlayer(g_capt2) && g_capt1 != g_capt2) {
           g_LiveTimerRunning = false;
-          PrintHintTextToAll("%t\n%t", "ReadyStatusPlayers", readyPlayers, totalPlayers,
+          PrintHintTextToAll("%t\n%t", "ReadyStatusPlayers", readyPlayers, neededPlayers,
                              "ReadyStatusAllReadyVeto");
           PugSetup_MessageToAll("%t", "VetoMessage");
           CreateTimer(2.0, MapSetup, _, TIMER_FLAG_NO_MAPCHANGE);
@@ -645,7 +647,7 @@ public Action Timer_CheckReady(Handle timer) {
 
       } else {
         g_LiveTimerRunning = false;
-        PrintHintTextToAll("%t\n%t", "ReadyStatusPlayers", readyPlayers, totalPlayers,
+        PrintHintTextToAll("%t\n%t", "ReadyStatusPlayers", readyPlayers, neededPlayers,
                            "ReadyStatusAllReadyVote");
         PugSetup_MessageToAll("%t", "VoteMessage");
         CreateTimer(2.0, MapSetup, _, TIMER_FLAG_NO_MAPCHANGE);
@@ -663,7 +665,7 @@ public Action Timer_CheckReady(Handle timer) {
   Call_Finish();
 
   if (g_TeamType == TeamType_Captains && g_AutoRandomizeCaptainsCvar.IntValue != 0 &&
-      totalPlayers >= PugSetup_GetPugMaxPlayers()) {
+      totalPlayers >= neededPlayers) {
     // re-randomize captains if they aren't set yet
     if (!IsPlayer(g_capt1)) {
       g_capt1 = RandomPlayer();


### PR DESCRIPTION
I don't know if this happens with others, but I personally am confused with the the way the count of players is shown currently.

For example, if the game needs 10 players but the server only has 6 and they're all ready, the message will say `6 of 6 players are ready`, which would indicate that the game is ready to go since everybody is ready.

Showing "6 of 10" makes more sense since it clearly and immediately shows the number of needed players.