### PR TITLE
fix client index not found

### DIFF
--- a/scripting/pugsetup/captainpickmenus.sp
+++ b/scripting/pugsetup/captainpickmenus.sp
@@ -6,6 +6,8 @@ public Action Timer_InitialChoiceMenu(Handle timer) {
   int client = g_capt1;
   
   if(!IsClientInGame(client))
+    PugSetup_MessageToAll("A captain is missing, aborting the game.");
+    EndMatch(false);
     return Plugin_Handled;
     
   if (!g_DoKnifeRound) {

--- a/scripting/pugsetup/captainpickmenus.sp
+++ b/scripting/pugsetup/captainpickmenus.sp
@@ -4,7 +4,10 @@ int g_PickCounter = 0;
 
 public Action Timer_InitialChoiceMenu(Handle timer) {
   int client = g_capt1;
-
+  
+  if(!IsClientInGame(client))
+    return Plugin_Handled;
+    
   if (!g_DoKnifeRound) {
     // if no knife rounds, they get to choose between side/1st pick
     Menu menu = new Menu(InitialChoiceHandler);


### PR DESCRIPTION
Fixed this error

```
L 07/21/2022 - 10:26:18: [SM] Exception reported: Client index -1 is invalid
L 07/21/2022 - 10:26:18: [SM] Blaming: pugsetup.smx
L 07/21/2022 - 10:26:18: [SM] Call stack trace:
L 07/21/2022 - 10:26:18: [SM]   [0] GetClientSerial
L 07/21/2022 - 10:26:18: [SM]   [1] Line 19, ./scripting/pugsetup/captainpickmenus.sp::Timer_InitialChoiceMenu
```